### PR TITLE
Added username and password with secrets to set up HTTP AUTH on redis…

### DIFF
--- a/repo/packages/C/cdpq-rediscommander/10002/config.json
+++ b/repo/packages/C/cdpq-rediscommander/10002/config.json
@@ -173,11 +173,23 @@
           "description": "Redis Port",
           "type": "string",
           "default": "6379"
+        },
+        "REDISCOMMANDER_USERNAME": {
+          "description": "Secret in secret store for the rq-dashboard username",
+          "type": "string",
+          "default": ""
+        },
+        "REDISCOMMANDER_PASSWORD": {
+          "description": "Secret in secret store for the rq-dashboard password",
+          "type": "string",
+          "default": ""
         }
       },
       "required": [
         "REDIS_HOST",
-        "REDIS_PORT"
+        "REDIS_PORT",
+        "REDISCOMMANDER_USERNAME",
+        "REDISCOMMANDER_PASSWORD"
       ]
     },
     "fetch": {

--- a/repo/packages/C/cdpq-rediscommander/10002/marathon.json.mustache
+++ b/repo/packages/C/cdpq-rediscommander/10002/marathon.json.mustache
@@ -56,7 +56,17 @@
     {{^networking.marathon_lb_proxy.enabled}}
     "URL_PREFIX": "/service/{{service.name}}",
     {{/networking.marathon_lb_proxy.enabled}}
+    "HTTP_USER": {"secret": "rediscommanderusername"},
+    "HTTP_PASSWORD": {"secret": "rediscommanderpassword"},
     "REDIS_PORT": "{{environment.REDIS_PORT}}"
+  },
+  "secrets": {
+    "rediscommanderusername": {
+      "source": "{{environment.REDISCOMMANDER_USERNAME}}"
+    },
+    "rediscommanderpassword": {
+      "source": "{{environment.REDISCOMMANDER_PASSWORD}}"
+    }
   },
   "healthChecks": [
     {


### PR DESCRIPTION
…commander. Tested on dv2 with proxy. Tested on aws setup, but could not work because edgelb is not properly setup- should work when properly setup